### PR TITLE
feat: Add monospace font detection

### DIFF
--- a/examples/query.rs
+++ b/examples/query.rs
@@ -1,0 +1,15 @@
+use rust_fontconfig::{FcFontCache, FcPattern, PatternMatch};
+
+fn main() {
+    let cache = FcFontCache::build();
+    let fonts = cache.query_all(&FcPattern {
+        monospace: PatternMatch::True,
+        ..Default::default()
+    });
+
+    println!("total fonts: {}", fonts.len());
+
+    for font in fonts {
+        println!("{:?}", font);
+    }
+}


### PR DESCRIPTION
1. Check the post Table
The post table (PostScript table) contains a field called isFixedPitch. This field is a boolean value:

If isFixedPitch is set to 1, the font is monospace.
If isFixedPitch is set to 0, the font is proportional.

2. Inspect the hhea Table
The hhea (Horizontal Header) table contains the advanceWidthMax field. In a monospace font, all glyphs have the same advance width, so this value will be consistent across all glyphs.

3. Examine the OS/2 Table
The OS/2 table includes the panose field, which describes the visual characteristics of the font. The first byte of the panose array (the Family Type) can indicate if the font is monospace:
A value of 2 in the Family Type indicates a monospace font.